### PR TITLE
fix Invalid cross-device link

### DIFF
--- a/ManifestEditor/__init__.py
+++ b/ManifestEditor/__init__.py
@@ -39,7 +39,7 @@ def modify_apk_attr(input_apk, attr_obj, new_attr_obj, output_apk=None):
     zip_out.close()
     if not output_apk:
         output_apk = input_apk
-    os.rename(tmp_apk, output_apk)
+    shutil.move(tmp_apk, output_apk)
 
 def get_apk_attr(input_apk, attr_obj):
     tmp_xml = _get_androidmanifest(input_apk)


### PR DESCRIPTION
如果目标的位置是不同的数据盘，会触发 OSError: [Errno 18] Invalid cross-device link 异常，使用shutil.move